### PR TITLE
Enable workflow to run cellranger alone if no batch information is provided

### DIFF
--- a/workflows/preprocess/preprocess.wdl
+++ b/workflows/preprocess/preprocess.wdl
@@ -67,12 +67,12 @@ workflow preprocess {
 		File molecule_info_output = select_first([cellranger_count.molecule_info, cellranger_molecule_info]) #!FileCoercion
 		File metrics_csv_output = select_first([cellranger_count.metrics_csv, cellranger_metrics_csv]) #!FileCoercion
 
-		if (counts_to_seurat_complete == "false") {
+		if (counts_to_seurat_complete == "false" && defined(sample.batch)) {
 			# Import counts and convert to a Seurat object
 			call counts_to_seurat {
 				input:
 					sample_id = sample.sample_id,
-					batch = sample.batch,
+					batch = select_first([sample.batch]),
 					raw_counts = raw_counts_output, # !FileCoercion
 					filtered_counts = filtered_counts_output, # !FileCoercion
 					soup_rate = soup_rate,

--- a/workflows/structs.wdl
+++ b/workflows/structs.wdl
@@ -2,7 +2,7 @@ version 1.0
 
 struct Sample {
 	String sample_id
-	String batch
+	String? batch
 
 	File fastq_R1
 	File fastq_R2


### PR DESCRIPTION
This will run the upstream cellranger_count task, which does not require batch information, and if batch information is not provided the analysis will stop before running counts_to_seurat.
This allows the workflow to be picked up after cellranger when batch information is available for samples.