### PR TITLE
Allow optional index files to be provided to cellranger

### DIFF
--- a/util/generate_inputs
+++ b/util/generate_inputs
@@ -6,11 +6,12 @@ import re
 import json
 
 
-def load_fastq_locs(fastq_locs_txt):
+def load_fastq_locs(fastq_locs_txt_list):
     fastq_locs = []
-    with open(fastq_locs_txt, "r") as f:
-        for line in f:
-            fastq_locs.append(line.strip())
+    for fastq_locs_txt in fastq_locs_txt_list:
+        with open(fastq_locs_txt, "r") as f:
+            for line in f:
+                fastq_locs.append(line.strip())
 
     # Ensure fastq locs are sorted alphabetically, so that *_R1 will always show up before *_R2
     fastq_locs.sort()
@@ -19,22 +20,53 @@ def load_fastq_locs(fastq_locs_txt):
 
 
 def get_fastq_locs(fastq_path, sample_id, fastq_locs):
-    fastqs = [
+    sample_fastqs = [
         fastq_loc
         for fastq_loc in fastq_locs
         if re.search(rf"{fastq_path}/{sample_id}", fastq_loc)
     ]
 
-    # Confirm that there are exactly 2 fastqs, and the string 'R1' is in the first, 'R2' in the second
-    if len(fastqs) != 2:
+    fastq_R1s = [
+        fastq_loc
+        for fastq_loc in sample_fastqs
+        if re.search(rf"{fastq_path}/{sample_id}.*R1.*", fastq_loc)
+    ]
+    fastq_R2s = [
+        fastq_loc
+        for fastq_loc in sample_fastqs
+        if re.search(rf"{fastq_path}/{sample_id}.*R2.*", fastq_loc)
+    ]
+    fastq_I1s = [
+        fastq_loc
+        for fastq_loc in sample_fastqs
+        if re.search(rf"{fastq_path}/{sample_id}.*I1.*", fastq_loc)
+    ]
+    fastq_I2s = [
+        fastq_loc
+        for fastq_loc in sample_fastqs
+        if re.search(rf"{fastq_path}/{sample_id}.*I2.*", fastq_loc)
+    ]
+
+    if len(fastq_R1s) != 1 or len(fastq_R2s) != 1:
         raise SystemExit(
-            f"Unexpected number of FASTQS ({len(fastqs)}) found for sample {sample_id}\n{fastqs}"
+            f"Expected to find 'R1' in read 1 and 'R2' in read 2, but didn't for sample {sample_id}\nR1s: {fastq_R1s}\nR2s: {fastq_R2s}"
         )
-    elif "R1" not in fastqs[0] or "R2" not in fastqs[1]:
+    elif any(
+        [
+            len(fastq_set) > 1
+            for fastq_set in [fastq_R1s, fastq_R2s, fastq_I1s, fastq_I2s]
+        ]
+    ):
         raise SystemExit(
-            f"Expected to find 'R1' in read 1 and 'R2' in read 2, but didn't for sample {sample_id}\nR1: {fastqs[0]}\nR2: {fastqs[1]}"
+            f"Unexpected number of FASTQS found for sample {sample_id}\nR1s: {fastqs_R1s}\nR2s: {fastq_R2s}\nI1s: {fastq_I1s}\nI2s: {fastq_I2s}"
         )
-    return fastqs[0], fastqs[1]
+    else:
+        fastq_R1 = fastq_R1s[0]
+        fastq_R2 = fastq_R2s[0]
+        fastq_I1 = fastq_I1s[0] if len(fastq_I1s) > 0 else None
+        fastq_I2 = fastq_I2s[0] if len(fastq_I2s) > 0 else None
+
+    return fastq_R1, fastq_R2, fastq_I1, fastq_I2
 
 
 def main(args):
@@ -51,13 +83,23 @@ def main(args):
             batch = row.batch
             fastq_path = row.fastq_path
 
-            fastq_R1, fastq_R2 = get_fastq_locs(fastq_path, sample_id, fastq_locs)
+            fastq_R1, fastq_R2, fastq_I1, fastq_I2 = get_fastq_locs(
+                fastq_path, sample_id, fastq_locs
+            )
             sample = {
                 "sample_id": sample_id,
-                "batch": batch,
                 "fastq_R1": fastq_R1,
                 "fastq_R2": fastq_R2,
             }
+
+            if not pd.isna(batch):
+                sample["batch"] = batch
+
+            if fastq_I1:
+                sample["fastq_I1"] = fastq_I1
+
+            if fastq_I2:
+                sample["fastq_I2"] = fastq_I2
 
             if project_id not in projects:
                 projects[project_id] = {
@@ -112,16 +154,17 @@ if __name__ == "__main__":
         "--fastq-locs-txt",
         dest="fastq_locs_txt",
         type=str,
+        action="append",
         required=True,
-        help="File containing the location of all fastqs associated with samples; used to determine the path to the R1 and R2 files for each sample.",
+        help="File containing the location of all fastqs associated with samples; used to determine the path to the R1 and R2 files for each sample. Can provide one per project, or include all fastq locs in a single file.",
     )
     parser.add_argument(
         "-i",
         "--inputs-template",
         dest="inputs_template",
         type=str,
-        required=False,
-        help="If provided, use values supplied in the inputs template to write the output JSON file (projects will be added at the *.projects key).",
+        required=True,
+        help="Template JSON file to add project information to (projects will be added at the *.projects key).",
     )
     parser.add_argument(
         "-c",

--- a/workflows/preprocess/preprocess.wdl
+++ b/workflows/preprocess/preprocess.wdl
@@ -55,6 +55,8 @@ workflow preprocess {
 					sample_id = sample.sample_id,
 					fastq_R1 = sample.fastq_R1,
 					fastq_R2 = sample.fastq_R2,
+					fastq_I1 = sample.fastq_I1,
+					fastq_I2 = sample.fastq_I2,
 					cellranger_reference_data = cellranger_reference_data,
 					raw_data_path = raw_data_path,
 					curated_data_path = curated_data_path,
@@ -144,6 +146,8 @@ task cellranger_count {
 
 		File fastq_R1
 		File fastq_R2
+		File? fastq_I1
+		File? fastq_I2
 
 		File cellranger_reference_data
 
@@ -168,7 +172,7 @@ task cellranger_count {
 
 		# Ensure fastqs are in the same directory
 		mkdir fastqs
-		ln -s ~{fastq_R1} ~{fastq_R2} fastqs/
+		ln -s ~{fastq_R1} ~{fastq_R2} ~{fastq_I1} ~{fastq_I2} fastqs/
 
 		cellranger --version
 

--- a/workflows/structs.wdl
+++ b/workflows/structs.wdl
@@ -6,6 +6,8 @@ struct Sample {
 
 	File fastq_R1
 	File fastq_R2
+	File? fastq_I1
+	File? fastq_I2
 }
 
 struct Project {


### PR DESCRIPTION
Also edited the generate_inputs script to accomodate these optional inputs, and to allow batch to be null. Still assumes that there is only one set of paired fastqs per sample.