### PR TITLE
Feature/reduce storage

### DIFF
--- a/workflows/cohort_analysis/cluster_data/cluster_data.wdl
+++ b/workflows/cohort_analysis/cluster_data/cluster_data.wdl
@@ -35,9 +35,6 @@ workflow cluster_data {
 			integrated_adata_object = integrate_sample_data.integrated_adata_object, #!FileCoercion
 			scvi_latent_key =scvi_latent_key,
 			cell_type_markers_list = cell_type_markers_list,
-			raw_data_path = raw_data_path,
-			workflow_info = workflow_info,
-			billing_project = billing_project,
 			container_registry = container_registry,
 			zones = zones
 	}
@@ -55,9 +52,9 @@ workflow cluster_data {
 	}
 
 	output {
-		File integrated_adata_object = integrate_sample_data.integrated_adata_object #!FileCoercion
+		File integrated_adata_object = integrate_sample_data.integrated_adata_object
 		File scvi_model_tar_gz = integrate_sample_data.scvi_model_tar_gz #!FileCoercion
-		File umap_cluster_adata_object = cluster_cells.umap_cluster_adata_object #!FileCoercion
+		File umap_cluster_adata_object = cluster_cells.umap_cluster_adata_object
 		File cell_types_csv = annotate_cells.cell_types_csv #!FileCoercion
 		File cell_annotated_adata_object = annotate_cells.cell_annotated_adata_object #!FileCoercion
 		File cell_annotated_metadata = annotate_cells.cell_annotated_metadata #!FileCoercion
@@ -100,12 +97,11 @@ task integrate_sample_data {
 			-b ~{billing_project} \
 			-d ~{raw_data_path} \
 			-i ~{write_tsv(workflow_info)} \
-			-o "~{cohort_id}.adata_object.scvi_integrated.h5ad" \
 			-o "~{cohort_id}_scvi_model.tar.gz"
 	>>>
 
 	output {
-		String integrated_adata_object = "~{raw_data_path}/~{cohort_id}.adata_object.scvi_integrated.h5ad"
+		File integrated_adata_object = "~{cohort_id}.adata_object.scvi_integrated.h5ad"
 		String scvi_model_tar_gz = "~{raw_data_path}/~{cohort_id}_scvi_model.tar.gz"
 	}
 
@@ -130,9 +126,6 @@ task cluster_cells {
 		String scvi_latent_key
 		File cell_type_markers_list
 
-		String raw_data_path
-		Array[Array[String]] workflow_info
-		String billing_project
 		String container_registry
 		String zones
 	}
@@ -148,16 +141,10 @@ task cluster_cells {
 			--adata-input ~{integrated_adata_object} \
 			--adata-output ~{integrated_adata_object_basename}.umap_cluster.h5ad \
 			--latent-key ~{scvi_latent_key}
-
-		upload_outputs \
-			-b ~{billing_project} \
-			-d ~{raw_data_path} \
-			-i ~{write_tsv(workflow_info)} \
-			-o "~{integrated_adata_object_basename}.umap_cluster.h5ad"
 	>>>
 
 	output {
-		String umap_cluster_adata_object = "~{raw_data_path}/~{integrated_adata_object_basename}.umap_cluster.h5ad"
+		File umap_cluster_adata_object = "~{integrated_adata_object_basename}.umap_cluster.h5ad"
 	}
 
 	runtime {

--- a/workflows/main.wdl
+++ b/workflows/main.wdl
@@ -67,7 +67,6 @@ workflow harmonized_pmdbs_analysis {
 			preprocess.graph_pdf,
 			preprocess.log,
 			preprocess.metrics_csv,
-			preprocess.checkpoint_tar_gz,
 			preprocess.posterior_probability,
 			preprocess.adata_object
 		]) #!StringCoercion
@@ -136,7 +135,6 @@ workflow harmonized_pmdbs_analysis {
 		Array[Array[File]] cellbender_graph_pdf = preprocess.graph_pdf
 		Array[Array[File]] cellbender_log = preprocess.log
 		Array[Array[File]] cellbender_metrics_csv = preprocess.metrics_csv
-		Array[Array[File]] cellbender_checkpoint_tar_gz = preprocess.checkpoint_tar_gz
 		Array[Array[File]] cellbender_posterior_probability = preprocess.posterior_probability
 		Array[Array[File]] adata_object = preprocess.adata_object
 

--- a/workflows/preprocess/preprocess.wdl
+++ b/workflows/preprocess/preprocess.wdl
@@ -359,7 +359,6 @@ task remove_technical_artifacts {
 		String log = "~{raw_data_path}/~{sample_id}.cellbender.log"
 		String metrics_csv = "~{raw_data_path}/~{sample_id}.cellbender_metrics.csv"
 		String posterior_probability = "~{raw_data_path}/~{sample_id}.cellbend_posterior.h5"
-		File checkpoint_tar_gz = "~{sample_id}.cellbender_ckpt.tar.gz"
 	}
 
 	runtime {

--- a/workflows/preprocess/preprocess.wdl
+++ b/workflows/preprocess/preprocess.wdl
@@ -91,7 +91,6 @@ workflow preprocess {
 		String cellbender_graph_pdf = "~{cellbender_raw_data_path}/~{sample.sample_id}.cellbender.pdf"
 		String cellbender_log = "~{cellbender_raw_data_path}/~{sample.sample_id}.cellbender.log"
 		String cellbender_metrics_csv = "~{cellbender_raw_data_path}/~{sample.sample_id}.cellbender_metrics.csv"
-		String cellbender_checkpoint_tar_gz = "~{cellbender_raw_data_path}/~{sample.sample_id}.cellbender_ckpt.tar.gz"
 		String cellbender_posterior_probability = "~{cellbender_raw_data_path}/~{sample.sample_id}.cellbend_posterior.h5"
 
 		if (cellbender_remove_background_complete == "false") {
@@ -115,7 +114,6 @@ workflow preprocess {
 		File graph_pdf_output = select_first([remove_technical_artifacts.graph_pdf, cellbender_graph_pdf]) #!FileCoercion
 		File log_output = select_first([remove_technical_artifacts.log, cellbender_log]) #!FileCoercion
 		File metrics_csv_output = select_first([remove_technical_artifacts.metrics_csv, cellbender_metrics_csv]) #!FileCoercion
-		File checkpoint_tar_gz_output = select_first([remove_technical_artifacts.checkpoint_tar_gz, cellbender_checkpoint_tar_gz]) #!FileCoercion
 		File posterior_probability_output = select_first([remove_technical_artifacts.posterior_probability, cellbender_posterior_probability]) #!FileCoercion
 
 		String preprocessed_adata_object = "~{adata_raw_data_path}/~{sample.sample_id}.adata_object.h5ad"
@@ -156,7 +154,6 @@ workflow preprocess {
 		Array[File] graph_pdf = graph_pdf_output #!FileCoercion
 		Array[File] log = log_output #!FileCoercion
 		Array[File] metrics_csv = metrics_csv_output #!FileCoercion
-		Array[File] checkpoint_tar_gz = checkpoint_tar_gz_output #!FileCoercion
 		Array[File] posterior_probability = posterior_probability_output #!FileCoercion
 
 		# AnnData counts
@@ -350,7 +347,6 @@ task remove_technical_artifacts {
 			-o "~{sample_id}.cellbender.pdf" \
 			-o "~{sample_id}.cellbender.log" \
 			-o "~{sample_id}.cellbender_metrics.csv" \
-			-o "~{sample_id}.cellbender_ckpt.tar.gz" \
 			-o "~{sample_id}.cellbend_posterior.h5"
 	>>>
 
@@ -362,8 +358,8 @@ task remove_technical_artifacts {
 		String graph_pdf = "~{raw_data_path}/~{sample_id}.cellbender.pdf"
 		String log = "~{raw_data_path}/~{sample_id}.cellbender.log"
 		String metrics_csv = "~{raw_data_path}/~{sample_id}.cellbender_metrics.csv"
-		String checkpoint_tar_gz = "~{raw_data_path}/~{sample_id}.cellbender_ckpt.tar.gz"
 		String posterior_probability = "~{raw_data_path}/~{sample_id}.cellbend_posterior.h5"
+		File checkpoint_tar_gz = "~{sample_id}.cellbender_ckpt.tar.gz"
 	}
 
 	runtime {


### PR DESCRIPTION
Do not store intermediate files (including intermediate adata objects) that are not necessary for long-term storage. This will save ~1.5 TB (before scanpy compression was implemented).